### PR TITLE
Fix corridor spelling and clarify comment

### DIFF
--- a/diversityViz.js
+++ b/diversityViz.js
@@ -617,7 +617,7 @@ export class DiversityVisualizer {
       camPos.x <= this.corridorBounds.xMax
     );
 
-    // If in corrider, Z driver ownership
+    // If the camera is in the corridor, moving along the Z-axis drives corporate ownership
     const now = performance.now();
 
     if (inCorridor) {


### PR DESCRIPTION
## Summary
- fix a typo in `diversityViz.js`
- clarify that Z-axis motion drives corporate ownership

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68409369154483339b6660428eb54227