### PR TITLE
Add shared getColor module with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Sobering Reality
+
+## Testing map utilities
+
+Run the Node test to verify `getColor` returns the expected colors:
+
+```bash
+node test_map_utils.js
+```
+
+It uses Node's built-in `assert` module and prints `All tests passed.` when successful.

--- a/corporate_ownership_map.html
+++ b/corporate_ownership_map.html
@@ -33,6 +33,8 @@
 <script src="https://d3js.org/d3.v7.min.js"></script>
 <!-- noUiSlider JS -->
 <script src="https://cdn.jsdelivr.net/npm/nouislider@15.7.1/dist/nouislider.min.js"></script>
+<!-- Utility functions -->
+<script src="map_utils.js"></script>
 
 <script>
 // Declare global vars
@@ -98,16 +100,6 @@ function styleFeature(feature) {
     color: 'white',
     fillOpacity: 0.7
   };
-}
-
-// 4. Get color from rate
-function getColor(rate) {
-  return rate > 0.5 ? '#67001f' :
-         rate > 0.4 ? '#b2182b' :
-         rate > 0.3 ? '#d6604d' :
-         rate > 0.2 ? '#f4a582' :
-         rate > 0.1 ? '#fddbc7' :
-                      '#f7f7f7';
 }
 
 // 5. Handle feature events

--- a/map_utils.js
+++ b/map_utils.js
@@ -1,0 +1,16 @@
+function getColor(rate) {
+  return rate > 0.5 ? '#67001f' :
+         rate > 0.4 ? '#b2182b' :
+         rate > 0.3 ? '#d6604d' :
+         rate > 0.2 ? '#f4a582' :
+         rate > 0.1 ? '#fddbc7' :
+                      '#f7f7f7';
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { getColor };
+}
+
+if (typeof window !== 'undefined') {
+  window.getColor = getColor;
+}

--- a/test_map_utils.js
+++ b/test_map_utils.js
@@ -1,0 +1,12 @@
+const assert = require('assert');
+const { getColor } = require('./map_utils.js');
+
+assert.strictEqual(getColor(0), '#f7f7f7');
+assert.strictEqual(getColor(0.15), '#fddbc7');
+assert.strictEqual(getColor(0.25), '#f4a582');
+assert.strictEqual(getColor(0.35), '#d6604d');
+assert.strictEqual(getColor(0.45), '#b2182b');
+assert.strictEqual(getColor(0.55), '#67001f');
+
+console.log('All tests passed.');
+


### PR DESCRIPTION
## Summary
- move `getColor` into new `map_utils.js`
- load `map_utils.js` in `corporate_ownership_map.html`
- add `test_map_utils.js` using Node `assert`
- document how to run tests in `README.md`

## Testing
- `node test_map_utils.js`


------
https://chatgpt.com/codex/tasks/task_e_684093b6fd148333a4a3193d6d52cfb9