### PR TITLE
Fix duplicate property init in DiversityVisualizer

### DIFF
--- a/diversityViz.js
+++ b/diversityViz.js
@@ -6,13 +6,6 @@ import { VRButton } from './VRButton.js';
 
 export class DiversityVisualizer {
   constructor(container) {
-    this.lastUpdateTime = 0;
-    this.updateInterval = 1000; // milliseconds
-    this.lastScrubProgress = null;
-
-    this.snapshotData = [];
-    this.snapshotReady = false;
-
     this.container = container;
     this.people = [];
     this.highlighted = null;


### PR DESCRIPTION
## Summary
- remove redundant property initialization in `DiversityVisualizer`

## Testing
- `node test_map_utils.js`

------
https://chatgpt.com/codex/tasks/task_e_68409b01fef08333857f9307781dd775